### PR TITLE
Native memory helpers

### DIFF
--- a/packages/mediapipe-core/lib/src/ffi_utils.dart
+++ b/packages/mediapipe-core/lib/src/ffi_utils.dart
@@ -76,3 +76,60 @@ int _length(Pointer<Uint8> codeUnits) {
   }
   return length;
 }
+
+/// Converts a pointer to a (representing a list of) floats to a list of
+/// Dart doubles.
+List<double> toDartListDouble(Pointer<Float> floats, {int? length}) {
+  if (floats.isNullPointer) {
+    throw Exception('Unexpected nullptr passed to `toDartListDouble`.');
+  }
+  final codeUnits = floats.cast<Float>();
+  if (length != null) {
+    RangeError.checkNotNegative(length, 'length');
+  } else {
+    length = lengthFloats(codeUnits);
+  }
+  final value = codeUnits.asTypedList(length);
+  return value;
+}
+
+/// Calculates the length of this array of floats by scanning for a value of 0.
+int lengthFloats(Pointer<Float> codeUnits) {
+  var length = 0;
+  while (codeUnits[length] != 0) {
+    length++;
+  }
+  return length;
+}
+
+/// Offers convenience and readability extensions for detecting null pointers.
+extension NullAwarePtr on Pointer {
+  /// Returns true if this is a null pointer.
+  bool get isNullPointer => address == 0;
+
+  /// Returns true if this is not a null pointer.
+  bool get isNotNullPointer => address != 0;
+}
+
+/// Returns true if this nullable pointer is both not-null and not a `NullPtr`,
+/// which is to say, its address is 0x00000000.
+bool isNotNullOrNullPointer(Pointer? ptr) =>
+    ptr != null && ptr.isNotNullPointer;
+
+/// Returns true if this nullable pointer is either null OR is a `NullPtr`,
+/// which is to say, its address is 0x00000000.
+bool isNullOrNullPointer(Pointer? ptr) => ptr == null || ptr.isNullPointer;
+
+/// Extension method for converting a [String] to a `Pointer<Utf8>`.
+extension NativeFloats on List<double> {
+  /// Creates a zero-terminated array of [Float]s from this list of doubles.
+  ///
+  /// Returns an [allocator]-allocated pointer to the result.
+  Pointer<Float> toNative({Allocator allocator = malloc}) {
+    final Pointer<Float> result = allocator<Float>(length + 1);
+    final Float32List nativeFloats = result.asTypedList(length + 1);
+    nativeFloats.setAll(0, this);
+    nativeFloats[length] = 0;
+    return result.cast();
+  }
+}

--- a/packages/mediapipe-core/test/ffi_utils_test.dart
+++ b/packages/mediapipe-core/test/ffi_utils_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+import 'package:mediapipe_core/mediapipe_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Floats should', () {
+    test('convert into Doubles', () {
+      final floats = malloc<Float>(2);
+      floats[0] = 1.0;
+      floats[1] = 2.0;
+      final doubles = toDartListDouble(floats, length: 2);
+      expect(doubles[0], closeTo(1.0, 0.00001));
+      expect(doubles[1], closeTo(2.0, 0.00001));
+      malloc.free(floats);
+    });
+
+    test('be converted from doubles', () {
+      final doubles = <double>[0.9, 1.1];
+
+      final floats = doubles.toNative();
+      expect(floats[0], closeTo(0.9, 0.00001));
+      expect(floats[1], closeTo(1.1, 0.00001));
+
+      final restoredDoubles = toDartListDouble(floats, length: 2);
+      expect(restoredDoubles[0], closeTo(0.9, 0.00001));
+      expect(restoredDoubles[1], closeTo(1.1, 0.00001));
+      malloc.free(floats);
+    });
+  });
+
+  group('Ints should', () {
+    test('convert into Dart ints', () {
+      final chars = malloc<Char>(2);
+      chars[0] = 1;
+      chars[1] = 2;
+      final normalInts = toUint8List(chars, length: 2);
+      expect(normalInts[0], 1);
+      expect(normalInts[1], 2);
+      malloc.free(chars);
+    });
+
+    test('be converted from Dart ints', () {
+      final chars = prepareUint8List(Uint8List.fromList([3, 4]));
+      expect(chars[0], 3);
+      expect(chars[1], 4);
+      malloc.free(chars);
+    });
+  });
+}


### PR DESCRIPTION
Adds helpers for converting between Dart and native memory for the following scenarios:

1. A list of Dart doubles <-> A list of native floats
2. A Dart `Uint8List` <-> A native `Pointer<Char>`.

Additionally, I would like to submit the function `Uint8List toUint8List(Pointer<Char> val, {int? length})` for code review, even though it was committed previously.

--

The context for this PR is work around [Embeddings](https://github.com/google/mediapipe/blob/master/mediapipe/tasks/c/components/containers/embedding_result.h#L31), which are currently emitting random results on sequential runs, and for which I want to rule out these low level memory mapping helpers.

cc @Piinks 